### PR TITLE
Deprecate in favor of Spacejam

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,4 @@
-travis-ci-laika
-=========================
+Deprecation notice 
+==================
 
-### [Travis CI support for Meteor with Laika](http://meteorhacks.com/continuos-integration-for-meteor-apps.html)
-
-Add following file to your meteor package as `.travis.yml`
-
-    language: node_js  
-    node_js:
-      - "0.10"
-    before_install:
-      - "curl -L http://git.io/3l-rRA | /bin/sh"
-    env:
-      - LAIKA_OPTIONS="-t 5000"
-
-Login to [https://travis-ci.org](https://travis-ci.org) with Github and navigate to [https://travis-ci.org/profile](https://travis-ci.org/profile)
-
-Enable travis support for your project listed there.
-
-![Travis CI support for Meteor with Laika](http://i.imgur.com/40L2CnU.png)
-
-See [here](http://meteorhacks.com/continuos-integration-for-meteor-apps.html) for more information
+Laika is no longer maintained. Please use [spacejam](https://github.com/practicalmeteor/spacejam) instead for CI testing.


### PR DESCRIPTION
Hi Arunoda,

I think that Laika is no longer maintained, is that correct? I haven't used it in a long while but today I saw that the official Travis guide points to it - http://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Meteor-Apps

Perhaps we should notify them to recommend spacejam instead?
